### PR TITLE
Fix bugs in noise

### DIFF
--- a/2_player_server/start_server.py
+++ b/2_player_server/start_server.py
@@ -62,13 +62,13 @@ Total_Ticks = 0
 global Stochasticity
 Stochasticity = args.NOISE
 if Stochasticity == 1:
-    noise1 = 0.005
-    noise2 = 0.01
-    noise3 = 2
+    noisePosition = 0.005
+    noiseForce = 0.01
+    noiseAngle = 2
 else:
-    noise1 = 0
-    noise2 = 0
-    noise3 = 0
+    noisePosition = 0
+    noiseForce = 0
+    noiseAngle = 0
 
 
 # Handle exceptions here
@@ -367,7 +367,7 @@ def validate(action, Player, state):
         # if angle>225:
         #     angle=225
     if Stochasticity == 1 and Player == 1:
-        angle = angle + (random.choice([-1, 1]) * gauss(0, noise3))
+        angle = angle + (random.choice([-1, 1]) * gauss(0, noiseAngle))
         # if angle>45:
         #     angle=45
         # if angle<135:
@@ -376,9 +376,9 @@ def validate(action, Player, state):
         angle = 360 + angle
     angle = angle / 180.0 * 3.14
     position = 170 + \
-        (float(max(min(position + gauss(0, noise2), 1), 0)) * (460))
+        (float(max(min(position + gauss(0, noiseForce), 1), 0)) * (460))
     force = MIN_FORCE + \
-        float(max(min(force + gauss(0, noise3), 1), 0)) * MAX_FORCE
+        float(max(min(force + gauss(0, noiseAngle), 1), 0)) * MAX_FORCE
 
     if Player == 1:
         check = 0
@@ -392,7 +392,7 @@ def validate(action, Player, state):
                     check = 0
                     print "Position ", (position, 145), " clashing with a coin, taking random"
                     position = 170 + \
-                        (float(max(min(float(random.random()) + gauss(0, noise1), 1), 0)) * (460))
+                        (float(max(min(float(random.random()) + gauss(0, noisePosition), 1), 0)) * (460))
     if Player == 2:
         check = 0
         fuse = 10
@@ -405,7 +405,7 @@ def validate(action, Player, state):
                     check = 0
                     print "Position ", (position, 145), " clashing with a coin, taking random"
                     position = 170 + \
-                        (float(max(min(float(random.random()) + gauss(0, noise1), 1), 0)) * (460))
+                        (float(max(min(float(random.random()) + gauss(0, noisePosition), 1), 0)) * (460))
 
     action = (angle, position, force)
     # print "Final action", action

--- a/2_player_server/start_server.py
+++ b/2_player_server/start_server.py
@@ -361,7 +361,7 @@ def validate(action, Player, state):
         force = random.random()
     global Stochasticity
     if Stochasticity == 1 and Player == 2:
-        angle = angle + randrange(-5, 5)
+        angle = angle + (random.choice([-1, 1]) * gauss(0, noiseAngle))
         # if angle<-45:
         #     angle=-45
         # if angle>225:
@@ -376,9 +376,9 @@ def validate(action, Player, state):
         angle = 360 + angle
     angle = angle / 180.0 * 3.14
     position = 170 + \
-        (float(max(min(position + gauss(0, noiseForce), 1), 0)) * (460))
+        (float(max(min(position + gauss(0, noisePosition), 1), 0)) * (460))
     force = MIN_FORCE + \
-        float(max(min(force + gauss(0, noiseAngle), 1), 0)) * MAX_FORCE
+        float(max(min(force + gauss(0, noiseForce), 1), 0)) * MAX_FORCE
 
     if Player == 1:
         check = 0


### PR DESCRIPTION
Force was using the variable `noise3` which was meant for Angle.
Position was using the variable `noise2` which was meant for Force.

Renamed variables to avoid such bugs.

-- --

In line 364 `angle = angle + randrange(-5, 5)`
Why does Player-2 have a different noise than Player-1?
Changed to match Player-1's angle noise.

-- --

I also don't understand why the Gaussian noise for angle was multiplied with +/- 1 even though it is already zero centred. `(random.choice([-1, 1]) * gauss(0, noiseAngle))`
That hasn't been done with the position/force noises though.